### PR TITLE
Add wikipedia command

### DIFF
--- a/src/Commands/general/Wikipedia.ts
+++ b/src/Commands/general/Wikipedia.ts
@@ -1,0 +1,76 @@
+import { CommandoMessage } from "discord.js-commando";
+import { Message, MessageEmbed } from "discord.js";
+
+import CorniCommand from "../../Engine/CorniCommand";
+import Cornibot from "../../Engine/CorniBot";
+import Logger from "../../Utils/Logger";
+import fetch from "node-fetch";
+
+export default class WikipediaCommand extends CorniCommand {
+    constructor(client: Cornibot) {
+        super(client, {
+            memberName: "wiki",
+            group: "general",
+            name: "wiki",
+            description: "Gets a quick wikipedia tldr; on a subject",
+            examples: ["wiki alan turing", "wiki docking"],
+            guildOnly: true,
+            args: [
+                {
+                    key: "query",
+                    label: "query",
+                    prompt: "What is your search query?",
+                    type: "string",
+                },
+            ],
+        });
+    }
+
+    async run2(msg: CommandoMessage, args: { query: string }): Promise<Message | Message[]> {
+        try {
+
+            let search_string = "https://en.wikipedia.org/w/api.php?action=query&format=json&prop=extracts|info&generator=prefixsearch&redirects=1&converttitles=1&utf8=1&formatversion=2&exchars=750&exintro=1&explaintext=1&exsectionformat=plain&inprop=url&gpslimit=5&gpsprofile=fuzzy&gpssearch=";
+            
+            let data = await fetch(search_string + args["query"]);
+
+            let json = await data.json();
+
+            if (json["query"] == null) {
+                return msg.reply("Topic not found.");
+            }
+
+            // Find best match (result with highest index)
+            let pages = json["query"]["pages"].sort(function(page1: { [x: string]: number; }, page2: { [x: string]: number; }) {
+                return page1["index"] - page2["index"];
+            });
+
+            if (pages[0]["extract"].includes("may refer to:")) {
+                // Multiple
+                let embed = new MessageEmbed()
+                    .setTitle("Wikipedia | " + pages[0]["title"])
+                    .setURL(pages[0]["fullurl"]);
+                
+                // Build list
+                let desc = "This may refer to:\n";
+                for (let i = 1; i < pages.length; i++) {
+                    desc += "- " + pages[i]["title"] + "\n";
+                }
+                embed.setDescription(desc);
+
+                return msg.say(embed);
+
+            } else {
+                //Single
+                return msg.say(
+                    new MessageEmbed()
+                        .setTitle("Wikipedia | " + pages[0]["title"])
+                        .setURL(pages[0]["fullurl"])
+                        .setDescription(pages[0]["extract"])
+                );
+            }
+        } catch (err) {
+            Logger.error("Error:", err);
+            return msg.reply("Something went wrong connecting to wikipedia... Try again later");
+        }
+    }
+}

--- a/src/Commands/general/Wikipedia.ts
+++ b/src/Commands/general/Wikipedia.ts
@@ -28,28 +28,25 @@ export default class WikipediaCommand extends CorniCommand {
 
     async run2(msg: CommandoMessage, args: { query: string }): Promise<Message | Message[]> {
         try {
+            const searchString =
+                "https://en.wikipedia.org/w/api.php?action=query&format=json&prop=extracts|info&generator=prefixsearch&redirects=1&converttitles=1&utf8=1&formatversion=2&exchars=750&exintro=1&explaintext=1&exsectionformat=plain&inprop=url&gpslimit=5&gpsprofile=fuzzy&gpssearch=";
+            const data = await fetch(searchString + args["query"]);
 
-            let search_string = "https://en.wikipedia.org/w/api.php?action=query&format=json&prop=extracts|info&generator=prefixsearch&redirects=1&converttitles=1&utf8=1&formatversion=2&exchars=750&exintro=1&explaintext=1&exsectionformat=plain&inprop=url&gpslimit=5&gpsprofile=fuzzy&gpssearch=";
-            
-            let data = await fetch(search_string + args["query"]);
-
-            let json = await data.json();
+            const json = await data.json();
 
             if (json["query"] == null) {
                 return msg.reply("Topic not found.");
             }
 
             // Find best match (result with highest index)
-            let pages = json["query"]["pages"].sort(function(page1: { [x: string]: number; }, page2: { [x: string]: number; }) {
+            const pages = json["query"]["pages"].sort(function (page1: { [x: string]: number }, page2: { [x: string]: number }) {
                 return page1["index"] - page2["index"];
             });
 
             if (pages[0]["extract"].includes("may refer to:")) {
                 // Multiple
-                let embed = new MessageEmbed()
-                    .setTitle("Wikipedia | " + pages[0]["title"])
-                    .setURL(pages[0]["fullurl"]);
-                
+                const embed = new MessageEmbed().setTitle("Wikipedia | " + pages[0]["title"]).setURL(pages[0]["fullurl"]);
+
                 // Build list
                 let desc = "This may refer to:\n";
                 for (let i = 1; i < pages.length; i++) {
@@ -58,7 +55,6 @@ export default class WikipediaCommand extends CorniCommand {
                 embed.setDescription(desc);
 
                 return msg.say(embed);
-
             } else {
                 //Single
                 return msg.say(


### PR DESCRIPTION
Adds a wikipedia searching command using the Wikipedia json api. Features priority sorting and special "refers to" parsing.

Sorry about my previous PR, I tried to the lazy github way and uploaded the file to the wrong folder. This time I uploaded the file to my own repo manually.